### PR TITLE
Fix comment placeholder color to match Itchy theme

### DIFF
--- a/components/CommentEditor.jsx
+++ b/components/CommentEditor.jsx
@@ -84,6 +84,7 @@ export default function CommentEditor({ onSubmit, reply, onClearReply, loading, 
             }}>
                 <TextInput
                     placeholder={commentsOpen ? "Add a comment..." : "Comments are disabled."}
+                    placeholderTextColor={colors.textSecondary}
                     style={{
                         width: width - 80,
                         color: colors.text,


### PR DESCRIPTION
## Description
Fixes the comment placeholder text not being visible in dark theme by explicitly setting the `placeholderTextColor` prop.

## Problem
The comment input field's placeholder text ("Add a comment..." / "Comments are disabled.") was invisible or barely visible because it was using the default placeholder color instead of a theme-aware color. This made it difficult for users to identify the input field and understand its purpose.

## Solution
Added `placeholderTextColor={colors.textSecondary}` to the `TextInput` component in `CommentEditor.jsx` to ensure the placeholder text has proper contrast against the dark background.

## Changes
- Added `placeholderTextColor` prop to the TextInput in CommentEditor component
- Uses `colors.textSecondary` from the theme system for consistency with other secondary text elements

Fixes #148