### PR TITLE
Support searching projects by project ID

### DIFF
--- a/app/(tabs)/search.jsx
+++ b/app/(tabs)/search.jsx
@@ -12,6 +12,8 @@ import {
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
 import APIExplore from "../../utils/api-wrapper/explore";
+import APIProject from "../../utils/api-wrapper/project";
+import { searchForProjects } from "../../utils/searchForProjects";
 import ProjectCard from "../../components/ProjectCard";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Chip from "../../components/Chip";
@@ -102,7 +104,11 @@ export default function Search() {
 
     switch (type) {
       case "projects":
-        APIExplore.searchForProjects(queryToSearch).then((data) => {
+        searchForProjects(
+          queryToSearch,
+          APIProject.getProject,
+          APIExplore.searchForProjects,
+        ).then((data) => {
           setResults(data);
           setIsLoading(false);
         });

--- a/test/project-search.test.mjs
+++ b/test/project-search.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { searchForProjects } from "../utils/searchForProjects.ts";
+
+test("looks up digit-only project queries by ID", async () => {
+  const calls = [];
+  const project = { id: 123456, title: "Project" };
+
+  const results = await searchForProjects(
+    " 123456 ",
+    async (id) => {
+      calls.push(["id", id]);
+      return project;
+    },
+    async (query) => {
+      calls.push(["name", query]);
+      return [];
+    },
+  );
+
+  assert.deepEqual(calls, [["id", "123456"]]);
+  assert.deepEqual(results, [project]);
+});
+
+test("keeps text project queries on name search", async () => {
+  const calls = [];
+  const projects = [{ id: 654321, title: "Similar name" }];
+
+  const results = await searchForProjects(
+    "Similar name",
+    async (id) => {
+      calls.push(["id", id]);
+      return {};
+    },
+    async (query) => {
+      calls.push(["name", query]);
+      return projects;
+    },
+  );
+
+  assert.deepEqual(calls, [["name", "Similar name"]]);
+  assert.deepEqual(results, projects);
+});

--- a/utils/searchForProjects.ts
+++ b/utils/searchForProjects.ts
@@ -1,0 +1,18 @@
+import type { Project } from "./api-wrapper/types/project";
+
+type GetProject = (id: string) => Promise<Project>;
+type SearchByName = (query: string) => Promise<Project[]>;
+
+export function searchForProjects(
+  query: string,
+  getProject: GetProject,
+  searchByName: SearchByName,
+): Promise<Project[]> {
+  const trimmedQuery = query.trim();
+
+  if (/^\d+$/.test(trimmedQuery)) {
+    return getProject(trimmedQuery).then((project) => [project]);
+  }
+
+  return searchByName(query);
+}


### PR DESCRIPTION
## Summary
- Route digit-only project queries through the direct project API.
- Preserve existing name-based project search behavior.
- Add focused tests for both query paths.

## Checks
- `OPENSSL_CONF=/dev/null node --experimental-strip-types --test test/project-search.test.mjs` — passed.
- `npm exec tsc -- --noEmit --pretty false` — unavailable because npm and installed dependencies were absent in the checkout environment.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1038:start -->
### Verification

[Northset proof-of-pass receipt M-1038](https://northset-oss.github.io/verification-pilot/receipts/M-1038/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1038:end -->
